### PR TITLE
Work on merge and strategies for automatic conflict resolution

### DIFF
--- a/nbdime/diff_format.py
+++ b/nbdime/diff_format.py
@@ -12,6 +12,9 @@ from collections import namedtuple
 from .log import NBDiffFormatError
 
 
+# TODO: Move some of the less official utilities in here to another submodule
+
+
 class DiffEntry(dict):
     def __getattr__(self, name):
         return self[name]
@@ -47,6 +50,9 @@ def make_op(op, *args):
     elif op == "patch":
         key, diff = args
         return DiffEntry(op=op, key=key, diff=diff)
+    elif op == "keep":
+        key, = args
+        return DiffEntry(op=op, key=key)
     else:
         raise NBDiffFormatError("Invalid op {}.".format(op))
 
@@ -60,6 +66,13 @@ class Diff(object):
     ADDRANGE = "addrange"
     REMOVERANGE = "removerange"
     PATCH = "patch"
+
+    # Not yet used in official diffs but possibly in
+    # internal tools or for future consideration
+    _KEEP = "keep"
+    #_MOVE = "move"
+    #_KEEPRANGE = "keeprange"
+    #_MOVERANGE = "moverange"
 
 
 class SequenceDiff(Diff):
@@ -95,6 +108,12 @@ class SequenceDiff(Diff):
 
     def patch(self, key, diff):
         self.append(make_op(Diff.PATCH, key, diff))
+
+    def addrange(self, key, valuelist):
+        self.append(make_op(Diff.ADDRANGE, key, valuelist))
+
+    def removerange(self, key, length):
+        self.append(make_op(Diff.REMOVERANGE, key, length))
 
 
 class MappingDiff(Diff):
@@ -243,6 +262,32 @@ def to_diffentry_dicts(di):  # TODO: Better name, validate_diff? as_diff?
         return [to_diffentry_dicts(v) for v in di]
     else:
         return di
+
+
+def decompress_sequence_diff(di, n):
+    """Convert sequence diff into pairs of (op, arg) for each n entries in base sequence.
+
+    This is for internal use in algorithms where no
+    insertions occur, making the mapping
+
+        index -> (op, arg)
+
+    possible with op in (KEEP, REMOVE, PATCH, REPLACE).
+    """
+    offset = 0
+    decompressed = [make_op(Diff._KEEP, i) for i in range(n)]
+    for e in di:
+        op = e.op
+        if op in (Diff.PATCH, Diff.REPLACE, Diff.REMOVE):
+            decompressed[e.key] = e
+        elif op == Diff.REMOVERANGE:
+            for i in range(e.length):
+                decompressed[e.key + i] = make_op(Diff.REMOVE, e.key + i)
+        elif op in (Diff.ADDRANGE, Diff.ADD):
+            raise ValueError("Not expexting insertions.")
+        else:
+            raise ValueError("Unknown op {}.".format(op))
+    return decompressed
 
 
 def as_dict_based_diff(di):

--- a/nbdime/diff_format.py
+++ b/nbdime/diff_format.py
@@ -255,6 +255,11 @@ def as_dict_based_diff(di):
     return {e.key: e for e in di}
 
 
+def revert_as_dict_based_diff(di):
+    "Reverts as_dict_based_diff."
+    return [di[k] for k in sorted(di)]
+
+
 def to_json_patch(d, path=""):
     """Convert nbdime diff object into the RFC6902 JSON Patch format.
 

--- a/nbdime/diffing/lcs.py
+++ b/nbdime/diffing/lcs.py
@@ -23,13 +23,13 @@ def diff_from_lcs(A, B, A_indices, B_indices):
         i = A_indices[r]
         j = B_indices[r]
         if i > x:
-            di.remove(x, i-x)
+            di.removerange(x, i-x)
         if j > y:
-            di.add(x, B[y:j])
+            di.addrange(x, B[y:j])
         x = i + 1
         y = j + 1
     if x < N:
-        di.remove(x, N-x)
+        di.removerange(x, N-x)
     if y < M:
-        di.add(x, B[y:M])
+        di.addrange(x, B[y:M])
     return di.diff  # XXX

--- a/nbdime/diffing/seq_difflib.py
+++ b/nbdime/diffing/seq_difflib.py
@@ -23,12 +23,12 @@ def opcodes_to_diff(a, b, opcodes):
             # Unlike difflib we don't represent equal stretches explicitly
             pass
         elif action == "replace":
-            di.remove(abegin, asize)
-            di.add(abegin, b[bbegin:bend])
+            di.removerange(abegin, asize)
+            di.addrange(abegin, b[bbegin:bend])
         elif action == "insert":
-            di.add(abegin, b[bbegin:bend])
+            di.addrange(abegin, b[bbegin:bend])
         elif action == "delete":
-            di.remove(abegin, asize)
+            di.removerange(abegin, asize)
         else:
             raise RuntimeError("Unknown action {}".format(action))
     return di.diff  # XXX

--- a/nbdime/diffing/snakes.py
+++ b/nbdime/diffing/snakes.py
@@ -83,9 +83,9 @@ def compute_diff_from_snakes(a, b, snakes, path="", predicates=None, differs=Non
     i0, j0, i1, j1 = 0, 0, len(a), len(b)
     for i, j, n in snakes + [(i1, j1, 0)]:
         if i > i0:
-            di.remove(i0, i-i0)
+            di.removerange(i0, i-i0)
         if j > j0:
-            di.add(i0, b[j0:j])
+            di.addrange(i0, b[j0:j])
 
         for k in range(n):
             aval = a[i + k]

--- a/nbdime/merging/autoresolve.py
+++ b/nbdime/merging/autoresolve.py
@@ -1,0 +1,240 @@
+# coding: utf-8
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import unicode_literals
+
+from six import string_types
+
+from ..diff_format import SequenceDiff, MappingDiff, Diff, make_op
+from ..diff_format import as_dict_based_diff, revert_as_dict_based_diff, decompress_sequence_diff
+from ..patching import patch
+
+
+def __find_strategy(path, strategies):
+    # Use closest parent strategy if specific entry is missing
+    strategy = strategies.get(path)
+    ppath = path
+    while strategy is None and ppath:
+        i = ppath.rfind("/")
+        if i >= 0:
+            ppath = ppath[:i]
+            strategy = strategies.get(path)
+        else:
+            break
+    return strategy
+
+
+# Strategies for handling conflicts  TODO: Implement these and refine further!
+#generic_conflict_strategies = ("mergetool", "use-base", "use-local", "use-remote", "fail")
+#source_conflict_strategies = generic_conflict_strategies + ("inline",)
+#transient_conflict_strategies = generic_conflict_strategies + ("clear",)
+#output_conflict_strategies = transient_conflict_strategies + ("use-all",)
+
+
+# Sentinel object
+Deleted = object()
+
+def __patch_item(value, diffentry):
+    op = diffentry.op
+    if op == Diff.REPLACE:
+        return diffentry.value
+    elif op == Diff.PATCH:
+        return patch(value, diffentry.diff)
+    elif op == Diff.REMOVE:
+        return Deleted
+    else:
+        raise ValueError("Invalid item patch op {}".format(op))
+
+def __make_join_diffentry(value, le, re):
+    # Joining e.g. an outputs list means concatenating all items
+    lvalue = patch_item(value, le)
+    rvalue = patch_item(value, re)
+
+    if lvalue is Deleted:
+        lvalue = []
+    if rvalue is Deleted:
+        rvalue = []
+    newvalue = value + lvalue + rvalue
+    e = FIXME
+    return e
+
+def __make_inline_diffentry(value, le, re):
+    # FIXME implement
+    e = FIXME
+    return e
+
+
+
+def cleared_value(value):
+    if isinstance(value, list):
+        # Clearing e.g. an outputs list means setting it to an empty list
+        return []
+    elif isinstance(value, dict):
+        # Clearing e.g. a metadata dict means setting it to an empty dict
+        return {}
+    elif isinstance(value, string_types):
+        # Clearing e.g. a source string means setting it to an empty string
+        return ""
+    else:
+        # Clearing anything else (atomic values) means setting it to None
+        return None
+
+
+def resolve_single_conflict(value, le, re, strategy, path):
+    assert le.key == re.key
+
+    if strategy == "fail":
+        raise RuntimeError("Not expecting a conflict at path {}.".format(path))
+
+    elif strategy == "mergetool":
+        e, le, re = None, le, re
+
+    elif strategy == "use-base":
+        e, le, re = None, None, None
+
+    elif strategy == "use-local":
+        e, le, re = le, None, None
+
+    elif strategy == "use-remote":
+        e, le, re = re, None, None
+
+    elif strategy == "clear":
+        v = cleared_value(value)
+        e = make_op(Diff.REPLACE, le.key, v)
+        le, re = None, None
+
+    # FIXME: Implement
+    #elif strategy == "inline":
+    #    e = make_inline_diffentry(value, le, re)
+    #    le, re = None
+
+    # FIXME: Implement
+    #elif strategy == "join":
+    #    e = make_join_diffentry(value, le, re)
+    #    le, re = None
+
+    else:
+        raise RuntimeError("Invalid strategy {}.".format(strategy))
+
+    return e, le, re
+
+
+def autoresolve_lists(merged, lcd, rcd, strategies, path):
+    key = "*"
+    subpath = "/".join((path, key))
+    strategy = strategies.get(subpath)
+
+    n = len(merged)
+    local = decompress_sequence_diff(lcd, n)
+    remote = decompress_sequence_diff(rcd, n)
+
+    resolutions = SequenceDiff()
+    newlcd = SequenceDiff()
+    newrcd = SequenceDiff()
+    for key, value in enumerate(merged):
+        # Figure out what lcd and rcd wants to do with merged[key]
+        le = local[key]
+        re = remote[key]
+
+        assert (le.op == Diff._KEEP) == (re.op == Diff._KEEP)
+
+        if le.op == Diff._KEEP or re.op == Diff._KEEP:
+            # Skip items without conflict
+            pass
+        elif strategy is not None:
+            # Autoresolve conflicts for this key
+            e, le, re = resolve_single_conflict(value, le, re, strategy, subpath)
+            if e is not None:
+                resolutions.append(e)
+            if le is not None:
+                newlcd.append(le)
+            if re is not None:
+                newrcd.append(re)
+        elif le.op == Diff.PATCH and re.op == Diff.PATCH:
+            # Recurse if we have no strategy for this key but diffs available for the subdocument
+            di, ldi, rdi = autoresolve(value, le.diff, re.diff, strategies, subpath)
+            if di:
+                resolutions.patch(key, di)
+            if ldi:
+                newlcd.patch(key, ldi)
+            if rdi:
+                newrcd.patch(key, rdi)
+        else:
+            # Alternatives if we don't have PATCH, are:
+            #  - INSERT: not happening
+            #  - REPLACE: technically possible, if so we can can convert it to PATCH, but does it happen?
+            #  - REMOVE: more likely, but resolving subdocument diff will still leave us with a full conflict on parent here
+            # No resolution, keep conflicts le, re
+            newlcd.append(le)
+            newrcd.append(re)
+
+    return resolutions.diff, newlcd.diff, newrcd.diff
+
+
+def autoresolve_dicts(merged, lcd, rcd, strategies, path):
+    # Converting to dict-based diff format for dicts for convenience
+    # This step will be unnecessary if we change the diff format to work this way always
+    lcd = as_dict_based_diff(lcd)
+    rcd = as_dict_based_diff(rcd)
+
+    # We can't have a one-sided conflict so keys must match
+    assert set(lcd) == set(rcd)
+
+    resolutions = MappingDiff()
+    newlcd = MappingDiff()
+    newrcd = MappingDiff()
+
+    for key in sorted(lcd):
+        # Query out how to handle conflicts in this part of the document
+        subpath = "/".join((path, key))
+        strategy = strategies.get(subpath)
+
+        # Get value and conflicts
+        value = merged[key]
+        le = lcd[key]
+        re = rcd[key]
+        assert le.key == key
+        assert re.key == key
+
+        if strategy is not None:
+            # Autoresolve conflicts for this key
+            e, le, re = resolve_single_conflict(value, le, re, strategy, subpath)
+            if e is not None:
+                resolutions.append(e)
+            if le is not None:
+                newlcd.append(le)
+            if re is not None:
+                newrcd.append(re)
+        elif le.op == Diff.PATCH and re.op == Diff.PATCH:
+            # Recurse if we have no strategy for this key but diffs available for the subdocument
+            di, ldi, rdi = autoresolve(value, le.diff, re.diff, strategies, subpath)
+            if di:
+                resolutions.patch(key, di)
+            if ldi:
+                newlcd.patch(key, ldi)
+            if rdi:
+                newrcd.patch(key, rdi)
+        else:
+            # Alternatives if we don't have PATCH, are:
+            #  - INSERT: not happening
+            #  - REPLACE: technically possible, if so we can can convert it to PATCH, but does it happen?
+            #  - REMOVE: more likely, but resolving subdocument diff will still leave us with a full conflict on parent here
+            # No resolution, keep conflicts le, re
+            newlcd.append(le)
+            newrcd.append(re)
+
+    return resolutions.diff, newlcd.diff, newrcd.diff
+
+
+def autoresolve(merged, local_diff, remote_diff, strategies, path):
+    """
+    Returns: resolution_diff, unresolved_local_diff, unresolved_remote_diff
+    """
+    if isinstance(merged, dict):
+        return autoresolve_dicts(merged, local_diff, remote_diff, strategies, path)
+    elif isinstance(merged, list):
+        return autoresolve_lists(merged, local_diff, remote_diff, strategies, path)
+    else:
+        raise RuntimeError("Invalid merged type {} at path {}".format(type(merged).__name__), path)

--- a/nbdime/merging/generic.py
+++ b/nbdime/merging/generic.py
@@ -86,6 +86,7 @@ def _merge_dicts(base, local, remote, base_local_diff, base_remote_diff):
         rop = rd.op
         if lop != rop: # Note that this means the below cases always have the same op
             # (5) Conflict: removed one place and edited another, or edited in different ways
+            merged[key] = bv
             local_conflict_diff.append(ld)
             remote_conflict_diff.append(rd)
         elif lop == Diff.REMOVE:
@@ -108,11 +109,13 @@ def _merge_dicts(base, local, remote, base_local_diff, base_remote_diff):
                     local_conflict_diff.patch(key, lco)
                     remote_conflict_diff.patch(key, rco)
             else:
-                # Recursive merge not possible, record a conflict
+                # Recursive merge not possible, record conflicting adds (no base value)
                 local_conflict_diff.append(ld)
                 remote_conflict_diff.append(rd)
         elif lop == Diff.REPLACE:
-            # (7) Replace in both local and remote, values are different
+            # (7) Replace in both local and remote, values are different,
+            #     record a conflict against original base value
+            merged[key] = bv
             local_conflict_diff.append(ld)
             remote_conflict_diff.append(rd)
         elif lop == Diff.PATCH:
@@ -316,7 +319,8 @@ def _merge_strings(base, local, remote, base_local_diff, base_remote_diff):
 
 def _merge(base, local, remote, base_local_diff, base_remote_diff):
     if not (type(base) == type(local) and type(base) == type(remote)):
-        raise ValueError("Expecting matching types, got {}, {}, and {}.".format(type(base), type(local), type(remote)))
+        raise ValueError("Expecting matching types, got {}, {}, and {}.".format(
+            type(base), type(local), type(remote)))
 
     if isinstance(base, dict):
         return _merge_dicts(base, local, remote, base_local_diff, base_remote_diff)
@@ -324,8 +328,13 @@ def _merge(base, local, remote, base_local_diff, base_remote_diff):
         return _merge_lists(base, local, remote, base_local_diff, base_remote_diff)
     elif isinstance(base, string_types):
         return _merge_strings(base, local, remote, base_local_diff, base_remote_diff)
+    else:
+        raise ValueError("Cannot handle merge of type {}.".format(type(base)))
 
-    raise ValueError("Cannot handle merge of type {}.".format(type(base)))
+
+def merge_with_diff(base, local, remote, base_local_diff, base_remote_diff):
+    """Do a three-way merge of same-type collections b, l, r with given diffs b->l and b->r."""
+    return _merge(base, local, remote, base_local_diff, base_remote_diff)
 
 
 def merge(base, local, remote):
@@ -479,4 +488,4 @@ def merge(base, local, remote):
     """
     base_local_diff = diff(base, local)
     base_remote_diff = diff(base, remote)
-    return _merge(base, local, remote, base_local_diff, base_remote_diff)
+    return merge_with_diff(base, local, remote, base_local_diff, base_remote_diff)

--- a/nbdime/merging/generic.py
+++ b/nbdime/merging/generic.py
@@ -252,13 +252,13 @@ def _merge_lists(base, local, remote, base_local_diff, base_remote_diff):
                     j = len(merged)
                     merged.append(base[i])
                     local_conflict_diff.patch(j, local_patched[i])
-                    remote_conflict_diff.remove(j, 1)
+                    remote_conflict_diff.removerange(j, 1)
                 elif rp:
                     # Conflict: Deleted local, patched remote
                     # NB! Note the use of j, index into merged, in the conflict diff!
                     j = len(merged)
                     merged.append(base[i])
-                    local_conflict_diff.remove(j, 1)
+                    local_conflict_diff.removerange(j, 1)
                     remote_conflict_diff.patch(j, remote_patched[i])
                 else:
                     # Not patched on alternate side, so delete it by just skipping value

--- a/nbdime/patching.py
+++ b/nbdime/patching.py
@@ -118,6 +118,8 @@ def patch(obj, diff):
         return patch_list(obj, diff)
     elif isinstance(obj, string_types):
         return patch_string(obj, diff)
+    else:
+        raise ValueError("Invalid object type to patch: {}".format(type(obj).__name__))
 
 
 def patch_notebook(nb, diff):

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -5,17 +5,163 @@
 
 from __future__ import unicode_literals
 
-#from six.moves import xrange as range
+import pytest
+import copy
+import nbformat
 
-#import copy
-#import pytest
-
-from nbdime import merge_notebooks
-
+from nbdime import merge_notebooks, merge, diff, patch
+from nbdime.merging.notebooks import autoresolve
 from .fixtures import sources_to_notebook
 
 
 # FIXME: Extend tests to more merge situations!
+
+
+def test_autoresolve_fail():
+    """Check that "fail" strategy results in proper exception raised."""
+
+    base = { "foo": 1 }
+    local = { "foo": 2 }
+    remote = { "foo": 3 }
+    strategies = { "/foo": "fail" }
+    merged, local_diffs, remote_diffs = merge(base, local, remote)
+    with pytest.raises(RuntimeError):
+        autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+
+    base = { "foo": {"bar":1} }
+    local = { "foo": {"bar":2} }
+    remote = { "foo": {"bar":3} }
+    strategies = { "/foo/bar": "fail" }
+    merged, local_diffs, remote_diffs = merge(base, local, remote)
+    with pytest.raises(RuntimeError):
+        autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+    strategies = { "/foo": "fail" }
+    merged, local_diffs, remote_diffs = merge(base, local, remote)
+    with pytest.raises(RuntimeError):
+        autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+
+
+def test_autoresolve_clear():
+    """Check strategy "clear" in various cases."""
+
+    base = { "foo": 1 }
+    local = { "foo": 2 }
+    remote = { "foo": 3 }
+    strategies = { "/foo": "clear" }
+    merged, local_diffs, remote_diffs = merge(base, local, remote)
+    assert merged == { "foo": 1 }
+    assert local_diffs != []
+    assert remote_diffs != []
+    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+    resolved = patch(merged, resolutions)
+    assert resolved == { "foo": None }
+    assert local_conflicts == []
+    assert remote_conflicts == []
+
+    #base = { "foo": [1] }
+    #local = { "foo": [2] }
+    #remote = { "foo": [3] }
+    #strategies = { "/foo": "clear" }
+    #merged, local_diffs, remote_diffs = merge(base, local, remote)
+    #resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+    #resolved = patch(merged, resolutions)
+    # This isn't happening because merge passes without conflict by removing [1] and adding [2,3] to foo:
+    #assert local_diffs != []
+    #assert remote_diffs != []
+    #assert merged == { "foo": [1] }
+    #assert resolved == { "foo": [] }
+    #assert local_conflicts == []
+    #assert remote_conflicts == []
+
+
+def test_autoresolve_use_one_side():
+    base = { "foo": 1 }
+    local = { "foo": 2 }
+    remote = { "foo": 3 }
+
+    strategies = { "/foo": "use-base" }
+    merged, local_diffs, remote_diffs = merge(base, local, remote)
+    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+    resolved = patch(merged, resolutions)
+    assert local_conflicts == []
+    assert remote_conflicts == []
+    assert resolved == { "foo": 1 }
+
+    strategies = { "/foo": "use-local" }
+    merged, local_diffs, remote_diffs = merge(base, local, remote)
+    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+    resolved = patch(merged, resolutions)
+    assert local_conflicts == []
+    assert remote_conflicts == []
+    assert resolved == { "foo": 2 }
+
+    strategies = { "/foo": "use-remote" }
+    merged, local_diffs, remote_diffs = merge(base, local, remote)
+    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+    resolved = patch(merged, resolutions)
+    assert local_conflicts == []
+    assert remote_conflicts == []
+    assert resolved == { "foo": 3 }
+
+
+    base = { "foo": {"bar": 1} }
+    local = { "foo": {"bar": 2} }
+    remote = { "foo": {"bar": 3} }
+
+    strategies = { "/foo/bar": "use-base" }
+    merged, local_diffs, remote_diffs = merge(base, local, remote)
+    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+    resolved = patch(merged, resolutions)
+    assert local_conflicts == []
+    assert remote_conflicts == []
+    assert resolved == { "foo": {"bar": 1 } }
+
+    strategies = { "/foo/bar": "use-local" }
+    merged, local_diffs, remote_diffs = merge(base, local, remote)
+    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+    resolved = patch(merged, resolutions)
+    assert local_conflicts == []
+    assert remote_conflicts == []
+    assert resolved == { "foo": {"bar": 2 } }
+
+    strategies = { "/foo/bar": "use-remote" }
+    merged, local_diffs, remote_diffs = merge(base, local, remote)
+    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
+    resolved = patch(merged, resolutions)
+    assert local_conflicts == []
+    assert remote_conflicts == []
+    assert resolved == { "foo": {"bar": 3 } }
+
+
+def test_autoresolve_notebook_ec():
+    args = None
+    # We need a source here otherwise the cells are not aligned
+    source = "def foo(x, y):\n    return x**y"
+
+    base = nbformat.v4.new_notebook()
+    base["cells"].append(nbformat.v4.new_code_cell())
+    base["cells"][0]["source"] = source
+    base["cells"][0]["execution_count"] = 1
+
+    local = copy.deepcopy(base)
+    remote = copy.deepcopy(base)
+    expected = copy.deepcopy(base)
+    local["cells"][0]["execution_count"] = 2
+    remote["cells"][0]["execution_count"] = 3
+    expected["cells"][0]["execution_count"] = None
+    
+    merged, local_conflicts, remote_conflicts = merge_notebooks(base, local, remote, args)
+
+    if 0:
+        print()
+        print(merged)
+        print(local_conflicts)
+        print(remote_conflicts)
+        print()
+
+    assert merged == expected
+    assert local_conflicts == []
+    assert remote_conflicts == []
 
 
 def test_merge_cell_sources_neighbouring_inserts():


### PR DESCRIPTION
This provides an initial implementation of an autoresolve feature with strategies configurable per path in json document. Good handling of source and outputs of notebooks is _not_ in place yet, but clearing differing execution_count and using base value in case of conflicting notebook or cell metadata should in principle work. Some basic tests are in place but more testing is needed.